### PR TITLE
Restore dropped transaction_args code

### DIFF
--- a/bin/spacewalk-action-package.py
+++ b/bin/spacewalk-action-package.py
@@ -122,6 +122,17 @@ class Zypper:
             Rollback do not check anything and will assume that state
             to which we are rolling back should be correct.
         """
+        args = ["-n", "-x", "install", "--"]
+
+        for pkgtup, action in transaction_data['packages']:
+            if ((action == "u") or (action == "i") or (action == "r")):
+                args.append("+" + __package_name_from_tup__(pkgtup))
+            elif action == 'e':
+                args.append("-" + __package_name_from_tup__(pkgtup))
+            else:
+                assert False, "Unknown package transaction action."
+        return args
+
     def patch_install(self, patch_list):
         args = ["-n", "-x", "install"]
         patches = ["patch:%s" % i for i in patch_list]


### PR DESCRIPTION
With 5709c505c by accident valuable transaction args code got dropped.
This was kind of correct, because it was really dead code at this
revision. The actual regression got caused by commit 245a40560 by
introducing patch_install function, which turned the transactions_args
code into deadcode.

This breaks in spacewalk synchronize profile.

Signed-off-by: Daniel Gollub gollub@b1-systems.de
