### PR TITLE
Force usage of official python

### DIFF
--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 13 10:13:15 CEST 2014 - fcastelli@suse.de
+
+- Changed the spec file to force usage of the official python VM; do
+  no longer use "!#/usr/bin/env python" as shebang. (bnc#889363)
+
+-------------------------------------------------------------------
 Tue May 13 08:48:25 CEST 2014 - mc@suse.de
 
 - require rhn-client-tools >= 1.7.7 which contains utf8_encode

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -46,6 +46,7 @@ a Spacewalk compatible server.
 %setup -q -n zypp-plugin-spacewalk
 
 %build
+egrep -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#\![ \t]*/usr/bin/env[ \t]\+python:\#\!/usr/bin/python:" {}
 
 %install
 %{__mkdir_p} %{buildroot}%{_prefix}/lib/zypp/plugins/services


### PR DESCRIPTION
Force zypper python code to use SUSE's official python VM. This prevents zypper failures when user install other python VMs on their system (see bnc#889363).
