### PR TITLE
Hint the user to uninstall the plugin if the machine will not be connected to Spacewalk

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -25,7 +25,7 @@ import os
 import traceback
 
 if not os.path.exists("/etc/sysconfig/rhn/systemid"):
-    sys.stderr.write("This client is not registered to any spacewalk server.\n")
+    sys.stderr.write("This system is not registered to any spacewalk server. If the system is not intended to be managed with spacewalk, please uninstall the zypp-plugin-spacewalk package.\n")
     sys.exit(1)
 
 # ma@suse.de: some modules seem to write debug output to stdout,


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=924042 describes when a user installs zypp-plugin-spacewalk by accident but the machine is not registered, zypper sees this as an error.

The following patch changes the behavior to just not give any channel to zypper (plus displaying the warning). I welcome a discussion, but I don't see why an error is necessary.
