### PR TITLE
up2date removed utf8_encode function and replace it with sstr in rhn.…

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -38,7 +38,10 @@ try:
     sys.path.append("/usr/share/rhn/")
     from up2date_client import rhnChannel
     from up2date_client import up2dateErrors
-    from up2date_client.rhncli import utf8_encode
+    try:
+        from up2date_client.rhncli import utf8_encode
+    except ImportError:
+        from rhn.i18n import sstr as utf8_encode
 except:
     sys.stderr.write("%sPlease install package spacewalk-backend-libs.\n" % traceback.format_exc())
     sys.exit(1)

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jan 22 16:07:28 CET 2016 - mc@suse.de
+
+- adapt for up2date client changes
+
+-------------------------------------------------------------------
 Fri Dec 11 13:21:14 CET 2015 - mc@suse.de
 
 - convert zypper output to valid UTF-8 (bsc#954602)


### PR DESCRIPTION
…i18n

spacewalk 2.5 removed the utf8_encode function and put several of them into rhn.i18n module.
