### PR TITLE
make pkg_gpgcheck configurable

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -91,6 +91,10 @@ for channel in svrChannels:
     # even if the original gpg_key_url is known.
     print >>sendback, "gpgcheck=0"
     # fate#314603 check package signature if metadata not signed
-    print >>sendback, "pkg_gpgcheck=1"
+    # allow disabling of package gpg check for custom channels
+    if hasattr(channel, 'pkg_gpgcheck'):
+        print >>sendback, "pkg_gpgcheck=%s" % utf8_encode(channel['pkg_gpgcheck'])
+    else:
+        print >>sendback, "pkg_gpgcheck=1"
     print >>sendback, "repo_gpgcheck=0"
 

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug  1 14:07:53 CEST 2017 - mantel@suse.de
+
+- make pkg_gpgcheck configurable
+- 0.9.14
+
+-------------------------------------------------------------------
 Fri Jan 22 16:07:28 CET 2016 - mc@suse.de
 
 - adapt for up2date client changes

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -17,7 +17,7 @@
 
 
 Name:           zypp-plugin-spacewalk
-Version:        0.9.13
+Version:        0.9.14
 Release:        0
 Summary:        Client side Spacewalk integration for ZYpp
 License:        GPL-2.0


### PR DESCRIPTION
After quite some lengthy discussion with the zypp maintainer, this is what we came up with and should be safe even on old SLES11 systems. If we do not get this flag in the channel info, we fall back to enabling package checks like in the past, so the new tools will continue to work even for an old SUSE Manager server.