### PR TITLE
Fix setting pkg_gpgcheck

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -93,9 +93,6 @@ for channel in svrChannels:
     print >>sendback, "gpgcheck=0"
     # fate#314603 check package signature if metadata not signed
     # allow disabling of package gpg check for custom channels
-    if hasattr(channel, 'pkg_gpgcheck'):
-        print >>sendback, "pkg_gpgcheck=%s" % utf8_encode(channel['pkg_gpgcheck'])
-    else:
-        print >>sendback, "pkg_gpgcheck=1"
+    print >>sendback, "pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1"))
     print >>sendback, "repo_gpgcheck=0"
 


### PR DESCRIPTION
The channels instance looks like this:

```
> /usr/lib/zypp/plugins/services/spacewalk(62)<module>()   
-> for channel in svrChannels:                             
(Pdb) pp channel             
<up2date_client.rhnChannel.rhnChannel instance at 0x7f713bdcae18>                                                     
(Pdb) dir(channel)           
['__doc__', '__getitem__', '__init__', '__lt__', '__module__', '__setitem__', 'dict', 'items', 'keys', 'values']
```
It doesn't have the `pkg_gpgcheck` attribute.
`channel.dict` looks like this:

```
(Pdb) pp channel.dict
{'arch': 'channel-x86_64',
 'description': '',
 'gpg_check': '0',
 'gpg_key_url': '',
 'id': '101',
 'label': 'testchannel',
 'local_channel': '1',
 'name': 'testchannel',
 'org_id': '1',
 'parent_channel': '',
 'summary': 'testchannel',
 'type': 'up2date',
 'url': ['https://mdsuma3pg.tf.local/XMLRPC'],
 'version': '20170804121603'}
```

In order to make this work I've changed the code to use channel.dict['gpg_check']
