### PR TITLE
adapt to upstream changes caused by a python3 port

### DIFF
--- a/actions/distupgrade.py
+++ b/actions/distupgrade.py
@@ -29,7 +29,10 @@ import xml.dom.minidom;
 from xml.dom import Node;
 
 from up2date_client import up2dateLog
-from actions.packages import Zypper
+try:
+    from actions.packages import Zypper
+except ImportError:
+    from rhn.actions.packages import Zypper
 
 log = up2dateLog.initLog()
 

--- a/actions/errata.py
+++ b/actions/errata.py
@@ -31,7 +31,10 @@ sys.path.append("/usr/share/rhn/")
 from up2date_client import rhnserver
 from up2date_client import up2dateAuth
 from up2date_client import rpmUtils
-from actions import packages
+try:
+    from actions import packages
+except ImportError:
+    from rhn.actions import packages
 
 __rhnexport__ = [
     'update']

--- a/actions/packages.py
+++ b/actions/packages.py
@@ -68,9 +68,9 @@ def __package_name_from_tup__(tup):
     if e:
         v = '%s:%s' % (e, v)
     if v:
-	pkginfo = '%s-%s' % (pkginfo, v)
+        pkginfo = '%s-%s' % (pkginfo, v)
     if r:
-	pkginfo = '%s-%s' % (pkginfo, r)
+        pkginfo = '%s-%s' % (pkginfo, r)
     return pkginfo
 
 class Zypper:
@@ -293,7 +293,7 @@ def setLocks(package_list, cache_only=None):
 
     try:
         os.rename(tmpf_name, '/etc/zypp/locks')
-    except OSError, e:
+    except OSError as e:
         error_message = "Error renaming '{tmpf_name}' to '/etc/zypp/locks': {error}".format(
             tmpf_name=tmpf_name, error=e.strerror)
         log.log_me(error_message)
@@ -397,7 +397,7 @@ def refresh_list(rhnsd=None, cache_only=None):
     try:
         rhnPackageInfo.updatePackageProfile()
     except:
-        print "ERROR: refreshing remote package list for System Profile"
+        print("ERROR: refreshing remote package list for System Profile")
         return (20, "Error refreshing package list", {})
 
     touch_time_stamp()
@@ -457,14 +457,14 @@ if __name__ == "__main__":
     #print update([['rubygem-thoughtbot-shoulda', '2.9.2', '1.1', '', 'x86_64']])
     #print remove([['ant', '1.7.1', '12.1', '', 'x86_64']])
 
-    print setLocks([
+    print(setLocks([
       ['rubygem-thoughtbot-shoulda', '2.9.2', '1.1', '', 'x86_64'],
       ['foo', '1.0.0', '1', '', ''],
       ['bar', '2.0.0', '2', '', '']
-    ])
+    ]))
     setLocks([])
     exit( 0 )
-    print "Transaction args:"
+    print("Transaction args:")
     transaction = { 'packages' : [
             [['foo', '1.0.0', '1', '', ''], 'e'],
             [ ['bar', '2.0.0', '2', '', ''], 'i'] ]}

--- a/bin/spacewalk-resolver.py
+++ b/bin/spacewalk-resolver.py
@@ -66,11 +66,11 @@ class SpacewalkResolverPlugin(Plugin):
             return
 
 
-        if not headers.has_key('channel'):
+        if 'channel' not in headers:
             self.answer("ERROR", {}, "Missing argument channel")
             return
 
-        if headers.has_key('server'):
+        if 'server' in headers:
             server = int(headers['server'])
         else:
             server = 0

--- a/bin/spacewalk-resolver.py
+++ b/bin/spacewalk-resolver.py
@@ -44,11 +44,11 @@ class SpacewalkResolverPlugin(Plugin):
 
     """ Pure exception handling """
     def RESOLVEURL(self, headers, body):
-	try:
-	    self.doRESOLVEURL(headers, body)
-	except up2dateErrors.Error as e:
+        try:
+            self.doRESOLVEURL(headers, body)
+        except up2dateErrors.Error as e:
             self.answer("ERROR", {}, str(e))
-	except:
+        except:
             self.answer("ERROR", {}, traceback.format_exc())
 
     """ RESOLVEURL action """
@@ -83,7 +83,7 @@ class SpacewalkResolverPlugin(Plugin):
         else:
             details = rhnChannel.getChannelDetails();
 
-	self.channel = None
+        self.channel = None
         for channel in details:
             if channel['label'] == headers['channel']:
                 self.channel = channel
@@ -96,14 +96,14 @@ class SpacewalkResolverPlugin(Plugin):
             login_info = up2dateAuth.getLoginInfo(timeout=timeout)
         else:
             login_info = up2dateAuth.getLoginInfo()
-	for k,v in login_info.items():
-	    if k in spacewalk_auth_headers:
-		self.auth_headers[k] = v
-	#self.answer("META", li)
+        for k,v in login_info.items():
+            if k in spacewalk_auth_headers:
+                self.auth_headers[k] = v
+        #self.answer("META", li)
 
-	# url is a list, use the one provided by the given server
-	if type(self.channel['url']) == type([]):
-	    self.channel['url'] = self.channel['url'][server]
+        # url is a list, use the one provided by the given server
+        if type(self.channel['url']) == type([]):
+            self.channel['url'] = self.channel['url'][server]
         timeoutstr = ""
         if timeout:
             timeoutstr = "&timeout=%d" % timeout

--- a/bin/spacewalk-resolver.py
+++ b/bin/spacewalk-resolver.py
@@ -46,7 +46,7 @@ class SpacewalkResolverPlugin(Plugin):
     def RESOLVEURL(self, headers, body):
 	try:
 	    self.doRESOLVEURL(headers, body)
-	except up2dateErrors.Error, e:
+	except up2dateErrors.Error as e:
             self.answer("ERROR", {}, str(e))
 	except:
             self.answer("ERROR", {}, traceback.format_exc())

--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -58,41 +58,41 @@ except:
     sys.exit(1)
 
 service_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
-print "# Channels for service %s" % service_name
+print("# Channels for service %s" % service_name)
 for channel in svrChannels:
-    print >>sendback
+    print(>>sendback)
     if channel['name']:
-        print >>sendback, "# Name:        %s" % utf8_encode(channel['name'])
+        print(>>sendback, "# Name:        %s" % utf8_encode(channel['name']))
     if channel['summary']:
-        print >>sendback, "# Summary:     %s" % utf8_encode(channel['summary'])
+        print(>>sendback, "# Summary:     %s" % utf8_encode(channel['summary']))
     if channel['description']:
-        print >>sendback, "# Description:"
+        print(>>sendback, "# Description:")
         for line in [line for line in channel['description'].split(os.linesep)]:
-            print >>sendback, "#   %s" % utf8_encode(line)
-        print >>sendback, "#"
+            print(>>sendback, "#   %s" % utf8_encode(line))
+        print(>>sendback, "#")
     if channel['type']:
-        print >>sendback, "# Type:         %s" % utf8_encode(channel['type'])
+        print(>>sendback, "# Type:         %s" % utf8_encode(channel['type']))
     if channel['version']:
-        print >>sendback, "# Version:      %s" % utf8_encode(channel['version'])
+        print(>>sendback, "# Version:      %s" % utf8_encode(channel['version']))
     if channel['arch']:
-        print >>sendback, "# Architecture: %s" % utf8_encode(channel['arch'])
+        print(>>sendback, "# Architecture: %s" % utf8_encode(channel['arch']))
     if channel['gpg_key_url']:
-        print >>sendback, "# Gpg Key:      %s" % utf8_encode(channel['gpg_key_url'])
-    print >>sendback, "[%s]" % utf8_encode(channel['label'])
-    print >>sendback, "name=%s" % utf8_encode(channel['name'])
+        print(>>sendback, "# Gpg Key:      %s" % utf8_encode(channel['gpg_key_url']))
+    print(>>sendback, "[%s]" % utf8_encode(channel['label']))
+    print(>>sendback, "name=%s" % utf8_encode(channel['name']))
     for i in range(0, len(channel['url'])):
-        print >>sendback, "baseurl=plugin:spacewalk?channel=%s&server=%d" % (utf8_encode(channel['label']),i)
-    print >>sendback, "enabled=1"
-    print >>sendback, "autorefresh=1"
+        print(>>sendback, "baseurl=plugin:spacewalk?channel=%s&server=%d" % (utf8_encode(channel['label']),i))
+    print(>>sendback, "enabled=1")
+    print(>>sendback, "autorefresh=1")
     if channel['type']:
-        print >>sendback, "type=%s" % utf8_encode(channel['type'])
+        print(>>sendback, "type=%s" % utf8_encode(channel['type']))
     if channel['gpg_key_url']:
-        print >>sendback, "gpgkey=%s" % utf8_encode(channel['gpg_key_url'])
+        print(>>sendback, "gpgkey=%s" % utf8_encode(channel['gpg_key_url']))
     # bnc#823917: Always disable gpgcheck as SMgr does not sign metadata,
     # even if the original gpg_key_url is known.
-    print >>sendback, "gpgcheck=0"
+    print(>>sendback, "gpgcheck=0")
     # fate#314603 check package signature if metadata not signed
     # allow disabling of package gpg check for custom channels
-    print >>sendback, "pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1"))
-    print >>sendback, "repo_gpgcheck=0"
+    print(>>sendback, "pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1")))
+    print(>>sendback, "repo_gpgcheck=0")
 

--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -34,6 +34,9 @@ if not os.path.exists("/etc/sysconfig/rhn/systemid"):
 sendback = sys.stdout
 sys.stdout = sys.stderr
 
+def _sendback(text):
+    sendback.write("{0}\n".format(text))
+
 try:
     sys.path.append("/usr/share/rhn/")
     from up2date_client import rhnChannel
@@ -60,39 +63,39 @@ except:
 service_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 print("# Channels for service %s" % service_name)
 for channel in svrChannels:
-    print(>>sendback)
+    _sendback("")
     if channel['name']:
-        print(>>sendback, "# Name:        %s" % utf8_encode(channel['name']))
+        _sendback("# Name:        %s" % utf8_encode(channel['name']))
     if channel['summary']:
-        print(>>sendback, "# Summary:     %s" % utf8_encode(channel['summary']))
+        _sendback("# Summary:     %s" % utf8_encode(channel['summary']))
     if channel['description']:
-        print(>>sendback, "# Description:")
+        _sendback("# Description:")
         for line in [line for line in channel['description'].split(os.linesep)]:
-            print(>>sendback, "#   %s" % utf8_encode(line))
-        print(>>sendback, "#")
+            _sendback("#   %s" % utf8_encode(line))
+        _sendback("#")
     if channel['type']:
-        print(>>sendback, "# Type:         %s" % utf8_encode(channel['type']))
+        _sendback("# Type:         %s" % utf8_encode(channel['type']))
     if channel['version']:
-        print(>>sendback, "# Version:      %s" % utf8_encode(channel['version']))
+        _sendback("# Version:      %s" % utf8_encode(channel['version']))
     if channel['arch']:
-        print(>>sendback, "# Architecture: %s" % utf8_encode(channel['arch']))
+        _sendback("# Architecture: %s" % utf8_encode(channel['arch']))
     if channel['gpg_key_url']:
-        print(>>sendback, "# Gpg Key:      %s" % utf8_encode(channel['gpg_key_url']))
-    print(>>sendback, "[%s]" % utf8_encode(channel['label']))
-    print(>>sendback, "name=%s" % utf8_encode(channel['name']))
+        _sendback("# Gpg Key:      %s" % utf8_encode(channel['gpg_key_url']))
+    _sendback("[%s]" % utf8_encode(channel['label']))
+    _sendback("name=%s" % utf8_encode(channel['name']))
     for i in range(0, len(channel['url'])):
-        print(>>sendback, "baseurl=plugin:spacewalk?channel=%s&server=%d" % (utf8_encode(channel['label']),i))
-    print(>>sendback, "enabled=1")
-    print(>>sendback, "autorefresh=1")
+        _sendback("baseurl=plugin:spacewalk?channel=%s&server=%d" % (utf8_encode(channel['label']),i))
+    _sendback("enabled=1")
+    _sendback("autorefresh=1")
     if channel['type']:
-        print(>>sendback, "type=%s" % utf8_encode(channel['type']))
+        _sendback("type=%s" % utf8_encode(channel['type']))
     if channel['gpg_key_url']:
-        print(>>sendback, "gpgkey=%s" % utf8_encode(channel['gpg_key_url']))
+        _sendback("gpgkey=%s" % utf8_encode(channel['gpg_key_url']))
     # bnc#823917: Always disable gpgcheck as SMgr does not sign metadata,
     # even if the original gpg_key_url is known.
-    print(>>sendback, "gpgcheck=0")
+    _sendback("gpgcheck=0")
     # fate#314603 check package signature if metadata not signed
     # allow disabling of package gpg check for custom channels
-    print(>>sendback, "pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1")))
-    print(>>sendback, "repo_gpgcheck=0")
+    _sendback("pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1")))
+    _sendback("repo_gpgcheck=0")
 

--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -48,10 +48,10 @@ except:
 
 try:
     svrChannels = rhnChannel.getChannelDetails()
-except up2dateErrors.NoSystemIdError, e:
+except up2dateErrors.NoSystemIdError as e:
     sys.stderr.write("%s\n" % e)
     sys.exit(42)
-except up2dateErrors.Error, e:
+except up2dateErrors.Error as e:
     sys.stderr.write("%s\n" % e)
     sys.exit(1)
 except:

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 28 07:42:59 UTC 2017 - mc@suse.com
+
+- 1.0.0
+- python3 compatibility
+- build python2/python3 subpackages
+
+-------------------------------------------------------------------
 Mon Aug  7 11:31:23 CEST 2017 - ma@suse.com
 
 - Fix setting pkg_gpgcheck

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -4,6 +4,7 @@ Thu Sep 28 07:42:59 UTC 2017 - mc@suse.com
 - 1.0.0
 - python3 compatibility
 - build python2/python3 subpackages
+- build as noarch for SLES12 and higher
 
 -------------------------------------------------------------------
 Mon Aug  7 11:31:23 CEST 2017 - ma@suse.com

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -185,6 +185,7 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 
 %if %{without rhnpath}
 %files -n python2-%{name}
+%defattr(-,root,root)
 %dir %{py2_actions}/actions
      %{py2_actions}/actions/packages.py*
      %{py2_actions}/actions/errata.py*
@@ -193,6 +194,7 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 
 %if %{with python3}
 %files -n python3-%{name}
+%defattr(-,root,root)
 %dir %{py3_actions}/actions
 %dir %{py3_actions}/actions/__pycache__
      %{py3_actions}/actions/packages.py*

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -67,24 +67,32 @@ Requires:       zypper >= 1.5.3
 # SLES12+
 Requires:       zypper(updatestack-only)
 %endif
-
-Requires:       python-xml
-
-Requires:       python
-BuildRequires:  python-devel
-Requires:       zypp-plugin-python
-
-Requires:       rhn-client-tools >= 1.7.7
 Requires:       zypper(oldpackage)
-%if %{with python3} || %{without rhnpath}
+
+%if %{without python3}
+Requires:       python
+Requires:       python-xml
+Requires:       zypp-plugin-python
+Requires:       rhn-client-tools >= 1.7.7
+Requires:       rhnlib
+BuildRequires:  python-devel
+%else
+Requires:       python3
+Requires:       zypp-plugin-python
+Requires:       rhn-client-tools >= 2.8.4
+Requires:       python3-rhnlib
+BuildRequires:  python3-devel
+%endif
+%if %{without rhnpath}
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
 %endif
+
 Provides:       zypp-media-plugin(spacewalk) = %{version}
 Provides:       zypp-service-plugin(spacewalk) = %{version}
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?suse_version} >= 1210
 BuildArch:      noarch
 %endif
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
 This plugin allows a ZYpp powered Linux system to see Spacewalk
@@ -97,6 +105,7 @@ Summary:        Client side Spacewalk integration for ZYpp
 Group:          System Environment/Base
 Requires:       %{name} = %{version}-%{release}
 Requires:       python2-rhn-client-tools >= 2.8.4
+BuildRequires:  python-devel
 
 %description -n python2-%{name}
 Python 2 specific files of %{name}

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -186,6 +186,7 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 %if %{without rhnpath}
 %files -n python2-%{name}
 %defattr(-,root,root)
+%dir %{py2_actions}
 %dir %{py2_actions}/actions
      %{py2_actions}/actions/packages.py*
      %{py2_actions}/actions/errata.py*
@@ -195,6 +196,7 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 %if %{with python3}
 %files -n python3-%{name}
 %defattr(-,root,root)
+%dir %{py3_actions}
 %dir %{py3_actions}/actions
 %dir %{py3_actions}/actions/__pycache__
      %{py3_actions}/actions/packages.py*

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -78,7 +78,7 @@ Requires:       rhnlib
 BuildRequires:  python-devel
 %else
 Requires:       python3
-Requires:       zypp-plugin-python
+Requires:       python3-zypp-plugin
 Requires:       rhn-client-tools >= 2.8.4
 Requires:       python3-rhnlib
 BuildRequires:  python3-devel

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -21,8 +21,8 @@
 %if 0%{?suse_version} > 1320
 %bcond_without python3
 %bcond_with rhnpath
-%global py2_actions %{python2_sitelib}
-%global py3_actions %{python3_sitelib}
+%global py2_actions %{python2_sitelib}/rhn
+%global py3_actions %{python3_sitelib}/rhn
 %define pythonX python3
 %else
 %bcond_with python3
@@ -31,7 +31,7 @@
 %global py2_actions %{_datadir}/rhn/
 %else
 %define pythonX python2
-%global py2_actions %{python2_sitelib}
+%global py2_actions %{python2_sitelib}/rhn
 %endif
 %endif
 
@@ -96,7 +96,7 @@ a Spacewalk compatible server.
 Summary:        Client side Spacewalk integration for ZYpp
 Group:          System Environment/Base
 Requires:       %{name} = %{version}-%{release}
-Requires:       python2-rhn-client-tools >= 1.7.7
+Requires:       python2-rhn-client-tools >= 2.8.4
 
 %description -n python2-%{name}
 Python 2 specific files of %{name}
@@ -109,7 +109,7 @@ Group:          System Environment/Base
 Requires:       %{name} = %{version}-%{release}
 BuildRequires:  python3-devel
 Requires:       python3
-Requires:       python3-rhn-client-tools >= 1.7.7
+Requires:       python3-rhn-client-tools >= 2.8.4
 
 %description -n python3-%{name}
 Python 3 specific files of %{name}
@@ -153,7 +153,7 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 %{__mkdir_p} %{buildroot}%{_var}/lib/up2date
 
 %if 0%{?suse_version}
-%py_compile %{buildroot}%{py2_actions}/actions
+%py_compile %{buildroot}%{py2_actions}
 %if %{with python3}
 %py3_compile %{buildroot}/%{py3_actions}
 %endif

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -119,7 +119,11 @@ Python 3 specific files of %{name}
 %setup -q -n zypp-plugin-spacewalk
 
 %build
+%if %{with python3}
+grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#\![ \t]*/usr/bin/env[ \t]\+python:\#\!/usr/bin/python3:" {}
+%else
 grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#\![ \t]*/usr/bin/env[ \t]\+python:\#\!/usr/bin/python:" {}
+%endif
 
 %install
 %{__mkdir_p} %{buildroot}%{_prefix}/lib/zypp/plugins/services

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -82,6 +82,9 @@ Requires:       %{pythonX}-%{name} = %{version}-%{release}
 Provides:       zypp-media-plugin(spacewalk) = %{version}
 Provides:       zypp-service-plugin(spacewalk) = %{version}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%if 0%{?suse_version} >= 1210
+BuildArch:      noarch
+%endif
 
 %description
 This plugin allows a ZYpp powered Linux system to see Spacewalk

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package zypp-plugin-spacewalk
 #
-# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,8 +15,8 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-%{!?python2_sitelib: %global python2_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
+%{!?python2_sitelib: %global python2_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 %if 0%{?suse_version} > 1320
 %bcond_without python3
@@ -34,7 +34,6 @@
 %global py2_actions %{python2_sitelib}
 %endif
 %endif
-
 
 Name:           zypp-plugin-spacewalk
 Version:        1.0.0
@@ -92,7 +91,6 @@ a Spacewalk compatible server.
 %if %{without rhnpath}
 %package -n python2-%{name}
 Summary:        Client side Spacewalk integration for ZYpp
-License:        GPL-2.0
 Group:          System Environment/Base
 Requires:       %{name} = %{version}-%{release}
 Requires:       python2-rhn-client-tools >= 1.7.7
@@ -104,7 +102,6 @@ Python 2 specific files of %{name}
 %if %{with python3}
 %package -n python3-%{name}
 Summary:        Client side Spacewalk integration for ZYpp
-License:        GPL-2.0
 Group:          System Environment/Base
 Requires:       %{name} = %{version}-%{release}
 BuildRequires:  python3-devel

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -37,7 +37,7 @@
 
 
 Name:           zypp-plugin-spacewalk
-Version:        0.9.16
+Version:        1.0.0
 Release:        0
 Summary:        Client side Spacewalk integration for ZYpp
 License:        GPL-2.0

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -15,6 +15,26 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%{!?python2_sitelib: %global python2_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+
+
+%if 0%{?suse_version} > 1320
+%bcond_without python3
+%bcond_with rhnpath
+%global py2_actions %{python2_sitelib}
+%global py3_actions %{python3_sitelib}
+%define pythonX python3
+%else
+%bcond_with python3
+%bcond_without rhnpath
+%if %{with rhnpath}
+%global py2_actions %{_datadir}/rhn/
+%else
+%define pythonX python2
+%global py2_actions %{python2_sitelib}
+%endif
+%endif
+
 
 Name:           zypp-plugin-spacewalk
 Version:        0.9.16
@@ -57,6 +77,9 @@ Requires:       zypp-plugin-python
 
 Requires:       rhn-client-tools >= 1.7.7
 Requires:       zypper(oldpackage)
+%if %{with python3} || %{without rhnpath}
+Requires:       %{pythonX}-%{name} = %{version}-%{release}
+%endif
 Provides:       zypp-media-plugin(spacewalk) = %{version}
 Provides:       zypp-service-plugin(spacewalk) = %{version}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -65,6 +88,32 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 This plugin allows a ZYpp powered Linux system to see Spacewalk
 subscribed repositories as well as downloading packages from the
 a Spacewalk compatible server.
+
+%if %{without rhnpath}
+%package -n python2-%{name}
+Summary:        Client side Spacewalk integration for ZYpp
+License:        GPL-2.0
+Group:          System Environment/Base
+Requires:       %{name} = %{version}-%{release}
+Requires:       python2-rhn-client-tools >= 1.7.7
+
+%description -n python2-%{name}
+Python 2 specific files of %{name}
+%endif
+
+%if %{with python3}
+%package -n python3-%{name}
+Summary:        Client side Spacewalk integration for ZYpp
+License:        GPL-2.0
+Group:          System Environment/Base
+Requires:       %{name} = %{version}-%{release}
+BuildRequires:  python3-devel
+Requires:       python3
+Requires:       python3-rhn-client-tools >= 1.7.7
+
+%description -n python3-%{name}
+Python 3 specific files of %{name}
+%endif
 
 %prep
 %setup -q -n zypp-plugin-spacewalk
@@ -82,10 +131,17 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 %{__install} bin/spacewalk-system.py %{buildroot}%{_prefix}/lib/zypp/plugins/system/spacewalk
 %{__install} bin/spacewalk-resolver.py %{buildroot}%{_prefix}/lib/zypp/plugins/urlresolver/spacewalk
 
-%{__mkdir_p} %{buildroot}%{_datadir}/rhn/actions
-%{__install} actions/packages.py %{buildroot}%{_datadir}/rhn/actions/
-%{__install} actions/errata.py %{buildroot}%{_datadir}/rhn/actions/
-%{__install} actions/distupgrade.py %{buildroot}%{_datadir}/rhn/actions/
+%{__mkdir_p} %{buildroot}%{py2_actions}/actions
+%{__install} actions/packages.py %{buildroot}%{py2_actions}/actions/
+%{__install} actions/errata.py %{buildroot}%{py2_actions}/actions/
+%{__install} actions/distupgrade.py %{buildroot}%{py2_actions}/actions/
+
+%if %{with python3}
+%{__mkdir_p} %{buildroot}%{py3_actions}/actions
+%{__install} actions/packages.py %{buildroot}%{py3_actions}/actions/
+%{__install} actions/errata.py %{buildroot}%{py3_actions}/actions/
+%{__install} actions/distupgrade.py %{buildroot}%{py3_actions}/actions/
+%endif
 
 %{__install} -m 0644 clientCaps/packages %{buildroot}%{_sysconfdir}/sysconfig/rhn/clientCaps.d/
 %if 0%{?sle_version} >= 120000
@@ -97,7 +153,10 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
 %{__mkdir_p} %{buildroot}%{_var}/lib/up2date
 
 %if 0%{?suse_version}
-%py_compile %{buildroot}%{_datadir}/rhn/actions
+%py_compile %{buildroot}%{py2_actions}/actions
+%if %{with python3}
+%py3_compile %{buildroot}/%{py3_actions}
+%endif
 %endif
 
 %files
@@ -111,15 +170,35 @@ grep -E -r -l "\#\!\s*/usr/bin/env\s+python" * | xargs -i -d "\n" sed -i -e"s:\#
      %{_prefix}/lib/zypp/plugins/system/spacewalk
 %dir %{_prefix}/lib/zypp/plugins/urlresolver
      %{_prefix}/lib/zypp/plugins/urlresolver/spacewalk
+%if %{with rhnpath}
 %dir %{_datadir}/rhn
 %dir %{_datadir}/rhn/actions
      %{_datadir}/rhn/actions/packages.py*
      %{_datadir}/rhn/actions/errata.py*
      %{_datadir}/rhn/actions/distupgrade.py*
+%endif
 %dir %{_var}/lib/up2date
 %dir %{_sysconfdir}/sysconfig/rhn
 %dir %{_sysconfdir}/sysconfig/rhn/clientCaps.d
 %config %{_sysconfdir}/sysconfig/rhn/clientCaps.d/packages
 %config %{_sysconfdir}/sysconfig/rhn/clientCaps.d/distupgrade
+
+%if %{without rhnpath}
+%files -n python2-%{name}
+%dir %{py2_actions}/actions
+     %{py2_actions}/actions/packages.py*
+     %{py2_actions}/actions/errata.py*
+     %{py2_actions}/actions/distupgrade.py*
+%endif
+
+%if %{with python3}
+%files -n python3-%{name}
+%dir %{py3_actions}/actions
+%dir %{py3_actions}/actions/__pycache__
+     %{py3_actions}/actions/packages.py*
+     %{py3_actions}/actions/errata.py*
+     %{py3_actions}/actions/distupgrade.py*
+     %{py3_actions}/actions/__pycache__/*.py*
+%endif
 
 %changelog


### PR DESCRIPTION
Upstream currenty do a drastic change to build python2 and python3 subpackages for actions
and put them in the standard python path.

This PR does the same for zypp-plugin-spacewalk and fix some python3 syntax errors in actions.
(We still need to check if the plugin is py3 compatible)

This PR introduce 2 conditions

--with(out) python3
--with(out) rhnpath

Building this module for SLES11 or SLES12, will still result in using /usr/share/rhn for actions and should not produce an python2-zypp-plugin-spacewalk package.
Building for SLE15 will produce python2/3 subpackages and the actions are moved under the python sitelib path. 

