### PR TITLE
Restore old gpgcheck behaviour with upstream Spacewalk

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -96,6 +96,10 @@ for channel in svrChannels:
     _sendback("gpgcheck=0")
     # fate#314603 check package signature if metadata not signed
     # allow disabling of package gpg check for custom channels
-    _sendback("pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1")))
+    # This conditional should restore the old behaviour with upstream Spacewalk
+    if not channel.dict.get('gpgcheck', None) and not channel['gpg_key_url']:
+        _sendback("pkg_gpgcheck=0")
+    else:
+        _sendback("pkg_gpgcheck=%s" % utf8_encode(channel.dict.get('gpgcheck', "1")))
     _sendback("repo_gpgcheck=0")
 


### PR DESCRIPTION
When registering a SUSE client against a Spacewalk server, this plugin would automatically turn on `pkg_gpgcheck=1` because the flag that is checked in the zypper plugin is only sent by SUSE Manager.
This pull request restores the old behaviour, that is to turn off GPG signature checks if no key url or fingerprints are configured for a software channel and the aforementioned flag is not present.