### PR TITLE
Prevent possible encoding issues on Python 3 (bsc#1152722)

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -31,11 +31,14 @@ if not os.path.exists("/etc/sysconfig/rhn/systemid"):
 # ma@suse.de: some modules seem to write debug output to stdout,
 # so we redirect it to stderr and use the original stdout for
 # sending back the result.
-sendback = sys.stdout
+if sys.version_info[0] >= 3:
+    sendback = sys.stdout.buffer
+else:
+    sendback = sys.stdout
 sys.stdout = sys.stderr
 
 def _sendback(text):
-    sendback.write("{0}\n".format(text))
+    sendback.write("{0}\n".format(text).encode())
 
 try:
     sys.path.append("/usr/share/rhn/")

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,3 +1,5 @@
+- Prevent possible encoding issues on Python 3 (bsc#1152722)
+
 -------------------------------------------------------------------
 Thu May 23 16:44:42 UTC 2019 - psuarezhernandez@suse.com
 


### PR DESCRIPTION
This PR prevents possible encoding issues on Python 3 when receiving channels descriptions:

```
>>> os.system("zypper ref")
Refreshing service 'spacewalk'.
Removing repository 'SLE-Manager-Tools15-Pool for ppc64le SAP SP1' [...done]
Removing repository 'SLE-Manager-Tools15-Updates for ppc64le SAP SP1' [...done]
Removing repository 'SLE-Module-Basesystem15-SP1-Pool for ppc64le SAP' [...done]
Removing repository 'SLE-Module-Basesystem15-SP1-Updates for ppc64le SAP' [...done]
Removing repository 'SLE-Module-Desktop-Applications15-SP1-Pool for ppc64le SAP' [...done]
Removing repository 'SLE-Module-Desktop-Applications15-SP1-Updates for ppc64le SAP' [...done]
Removing repository 'SLE-Module-DevTools15-SP1-Pool for ppc64le SAP' [...done]
Removing repository 'SLE-Module-DevTools15-SP1-Updates for ppc64le SAP' [...done]
Removing repository 'SLE-Module-SAP-Applications15-SP1-Pool for ppc64le' [...done]
Removing repository 'SLE-Module-SAP-Applications15-SP1-Updates for ppc64le' [...done]
Removing repository 'SLE-Module-Server-Applications15-SP1-Pool for ppc64le SAP' [...done]
Removing repository 'SLE-Module-Server-Applications15-SP1-Updates for ppc64le SAP' [...done]
Removing repository 'SLE-Product-HA15-SP1-Pool for ppc64le SAP' [...done]
Removing repository 'SLE-Product-HA15-SP1-Updates for ppc64le SAP' [...done]
Removing repository 'SLE-Product-SLES_SAP15-SP1-Pool for ppc64le' [...done]
Removing repository 'SLE-Product-SLES_SAP15-SP1-Updates for ppc64le' [...done]
Problem retrieving the repository index file for service 'spacewalk':
[spacewalk|file:/usr/lib/zypp/plugins/services/spacewalk] # Channels for service spacewalk
Traceback (most recent call last):
  File "/usr/lib/zypp/plugins/services/spacewalk", line 74, in <module>
    _sendback("#   %s" % utf8_encode(line))
  File "/usr/lib/zypp/plugins/services/spacewalk", line 38, in _sendback
    sendback.write("{0}\n".format(text))
UnicodeEncodeError: 'ascii' codec can't encode character '\u2019' in position 326: ordinal not in range(128)
```

Tracks: https://github.com/SUSE/spacewalk/issues/9735