### PR TITLE
Prevent issue with non-ASCII characters in Python 2 systems (bsc#1172462)

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -31,14 +31,8 @@ if not os.path.exists("/etc/sysconfig/rhn/systemid"):
 # ma@suse.de: some modules seem to write debug output to stdout,
 # so we redirect it to stderr and use the original stdout for
 # sending back the result.
-if sys.version_info[0] >= 3:
-    sendback = sys.stdout.buffer
-else:
-    sendback = sys.stdout
+sendback = sys.stdout
 sys.stdout = sys.stderr
-
-def _sendback(text):
-    sendback.write("{0}\n".format(text).encode())
 
 try:
     sys.path.append("/usr/share/rhn/")
@@ -51,6 +45,9 @@ try:
 except:
     sys.stderr.write("%sPlease install package spacewalk-backend-libs.\n" % traceback.format_exc())
     sys.exit(1)
+
+def _sendback(text):
+    sendback.write(utf8_encode("{0}\n".format(text)))
 
 try:
     svrChannels = rhnChannel.getChannelDetails()

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,3 +1,7 @@
+-------------------------------------------------------------------
+Fri Jun  5 11:27:08 UTC 2020 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>
+
+- 1.0.7
 - Prevent issue with non-ASCII characters in Python 2 systems (bsc#1172462)
 
 -------------------------------------------------------------------

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,3 +1,5 @@
+- Prevent issue with non-ASCII characters in Python 2 systems (bsc#1172462)
+
 -------------------------------------------------------------------
 Fri Oct 25 08:24:48 UTC 2019 - Pablo Suárez Hernández <pablo.suarezhernandez@suse.com>
 

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -36,7 +36,7 @@
 %endif
 
 Name:           zypp-plugin-spacewalk
-Version:        1.0.6
+Version:        1.0.7
 Release:        0
 Summary:        Client side Spacewalk integration for ZYpp
 License:        GPL-2.0


### PR DESCRIPTION
On https://github.com/openSUSE/zypp-plugin-spacewalk/pull/40/ we fixed possible encoding issues due different Python versions but the issues was not properly fixed for all different cases.

This new PR should fix these encoding issues properly by using the `rhn.i18n.sstr` method (already imported as `utf8_encoding`), which takes care of the proper cast depending on the running system.