### PR TITLE
require python macros for building

### DIFF
--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Dec 14 08:36:46 UTC 2021 - Michael Calmer <mc@suse.com>
+
+- 1.0.11
+  * require python macros for building
+
+-------------------------------------------------------------------
 Thu Oct 14 09:09:38 UTC 2021 - Michael Calmer <mc@suse.com>
 
 - 1.0.10

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -36,7 +36,7 @@
 %endif
 
 Name:           zypp-plugin-spacewalk
-Version:        1.0.10
+Version:        1.0.11
 Release:        0
 Summary:        Client side Spacewalk integration for ZYpp
 License:        GPL-2.0
@@ -82,6 +82,7 @@ Requires:       python3-zypp-plugin
 Requires:       rhn-client-tools >= 2.8.4
 Requires:       python3-rhnlib
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 %endif
 %if %{without rhnpath}
 Requires:       %{pythonX}-%{name} = %{version}-%{release}


### PR DESCRIPTION
Seems that python rpm macros are not instally by default anymore.
Require them explicitly 