### PR TITLE
Fix encoding function

### DIFF
--- a/bin/spacewalk-service.py
+++ b/bin/spacewalk-service.py
@@ -39,7 +39,7 @@ try:
     from up2date_client import rhnChannel
     from up2date_client import up2dateErrors
     try:
-        from up2date_client.rhncli import utf8_encode
+        from rhn.stringutils import sstr as utf8_encode
     except ImportError:
         from rhn.i18n import sstr as utf8_encode
 except:

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  1 08:56:55 UTC 2022 - Michael Calmer <mc@suse.com>
+
+- 1.0.12
+  * use new encoding function if available
+
+-------------------------------------------------------------------
 Tue Dec 14 08:36:46 UTC 2021 - Michael Calmer <mc@suse.com>
 
 - 1.0.11

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -36,7 +36,7 @@
 %endif
 
 Name:           zypp-plugin-spacewalk
-Version:        1.0.11
+Version:        1.0.12
 Release:        0
 Summary:        Client side Spacewalk integration for ZYpp
 License:        GPL-2.0


### PR DESCRIPTION
With SUSE Manager 4.3 rhn.i18n was renamed to rhn.stringutils.