### PR TITLE
Login before getting the list of channels

### DIFF
--- a/bin/spacewalk-resolver.py
+++ b/bin/spacewalk-resolver.py
@@ -78,6 +78,16 @@ class SpacewalkResolverPlugin(Plugin):
         # do we have spacewalk-client-tools with timeout option?
         args = getargspec(rhnChannel.getChannelDetails)[0]
         timeout = self._getTimeout()
+
+        self.auth_headers = {}
+        if 'timeout' in args:
+            login_info = up2dateAuth.getLoginInfo(timeout=timeout)
+        else:
+            login_info = up2dateAuth.getLoginInfo()
+        for k,v in list(login_info.items()):
+            if k in spacewalk_auth_headers:
+                self.auth_headers[k] = v
+
         if 'timeout' in args:
             details = rhnChannel.getChannelDetails(timeout=timeout)
         else:
@@ -90,16 +100,6 @@ class SpacewalkResolverPlugin(Plugin):
         if not self.channel:
             self.answer("ERROR", {}, "Can't retrieve information for channel %s" % headers['channel'])
             return
-
-        self.auth_headers = {}
-        if 'timeout' in args:
-            login_info = up2dateAuth.getLoginInfo(timeout=timeout)
-        else:
-            login_info = up2dateAuth.getLoginInfo()
-        for k,v in list(login_info.items()):
-            if k in spacewalk_auth_headers:
-                self.auth_headers[k] = v
-        #self.answer("META", li)
 
         proxystr = ""
         if rhnChannel.config.cfg['enableProxy'] == 1:

--- a/package/zypp-plugin-spacewalk.changes
+++ b/package/zypp-plugin-spacewalk.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 11 09:22:18 UTC 2022 - Cédric Bosdonnat <cbosdonnat@suse.com>
+
+- 1.0.13
+  * Log in before listing channels. bsc#1197963, bsc#1193585
+
+-------------------------------------------------------------------
 Tue Mar  1 08:56:55 UTC 2022 - Michael Calmer <mc@suse.com>
 
 - 1.0.12

--- a/package/zypp-plugin-spacewalk.spec
+++ b/package/zypp-plugin-spacewalk.spec
@@ -36,7 +36,7 @@
 %endif
 
 Name:           zypp-plugin-spacewalk
-Version:        1.0.12
+Version:        1.0.13
 Release:        0
 Summary:        Client side Spacewalk integration for ZYpp
 License:        GPL-2.0


### PR DESCRIPTION
The proxy assumes the client first calls login to cache the
authentication token headers... we'ld better call login before or the
listChannels would fail.

Related issues:
 * https://bugzilla.suse.com/show_bug.cgi?id=1193585
 * https://bugzilla.suse.com/show_bug.cgi?id=1197963